### PR TITLE
Fix spacing issue on contact page

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -637,7 +637,7 @@
                             <h3>Horaires d'ouverture</h3>
                             <table class="hours-table">
                                 <tr>
-                                    <td>Lundi - Vendredi</td>
+                                    <td>Lundi - Vendredi&nbsp;</td>
                                     <td>9h00 - 18h00</td>
                                 </tr>
                                 <tr>


### PR DESCRIPTION
## Summary
- ensure a space appears between the workdays and the opening time on contact page

## Testing
- `php -l contact.php`

------
https://chatgpt.com/codex/tasks/task_e_6866fd9eafa4832294e21840e617608f