### PR TITLE
Fix SQL syntax for created_at in post insert

### DIFF
--- a/admin/add_post.php
+++ b/admin/add_post.php
@@ -11,7 +11,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title']);
     $content = trim($_POST['content']);
     if ($title && $content) {
-        $stmt = $db->prepare("INSERT INTO posts (title, content, created_at) VALUES (?, ?, datetime('now'))");
+        // created_at is automatically set by the DB to the current timestamp
+        // so we simply omit it from the INSERT statement
+        $stmt = $db->prepare("INSERT INTO posts (title, content) VALUES (?, ?)");
         $stmt->execute([$title, $content]);
         $message = 'Article ajouté';
     } else {


### PR DESCRIPTION
## Summary
- fix SQL insert syntax in admin/add_post.php so created_at uses DB default

## Testing
- `php -l admin/add_post.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68670a9769688322b8cd97cf134fb9fd