### PR TITLE
Add sliding testimonial carousel

### DIFF
--- a/index.php
+++ b/index.php
@@ -340,8 +340,15 @@
         .testimonial-slider {
             max-width: 800px;
             margin: 0 auto;
-            text-align: center;
             position: relative;
+            overflow: hidden;
+            min-height: 220px;
+        }
+
+        .testimonial-track {
+            display: flex;
+            transition: transform 0.5s ease;
+            text-align: center;
         }
 
         .testimonial-nav {
@@ -359,6 +366,7 @@
         .testimonial-nav.next { right: -40px; }
         
         .testimonial {
+            flex: 0 0 100%;
             background-color: white;
             padding: 3rem;
             border-radius: 15px;
@@ -563,17 +571,19 @@
     <section class="testimonials">
         <h2>Témoignages</h2>
         <div class="testimonial-slider">
-            <div class="testimonial">
-                <p>"Caroline est une professionnelle exceptionnelle. Son approche médicale combinée à sa douceur fait toute la différence. Les résultats du Jet Peel sont incroyables !"</p>
-                <div class="testimonial-author">- Marie L.</div>
-            </div>
-            <div class="testimonial">
-                <p>"J'ai trouvé un véritable accompagnement personnalisé. Caroline met tout en œuvre pour notre confort."</p>
-                <div class="testimonial-author">- Jean P.</div>
-            </div>
-            <div class="testimonial">
-                <p>"Un service de qualité et des résultats visibles dès la première séance !"</p>
-                <div class="testimonial-author">- Sophie D.</div>
+            <div class="testimonial-track">
+                <div class="testimonial">
+                    <p>"Caroline est une professionnelle exceptionnelle. Son approche médicale combinée à sa douceur fait toute la différence. Les résultats du Jet Peel sont incroyables !"</p>
+                    <div class="testimonial-author">- Marie L.</div>
+                </div>
+                <div class="testimonial">
+                    <p>"J'ai trouvé un véritable accompagnement personnalisé. Caroline met tout en œuvre pour notre confort."</p>
+                    <div class="testimonial-author">- Jean P.</div>
+                </div>
+                <div class="testimonial">
+                    <p>"Un service de qualité et des résultats visibles dès la première séance !"</p>
+                    <div class="testimonial-author">- Sophie D.</div>
+                </div>
             </div>
             <button class="testimonial-nav prev" aria-label="Précédent"><i class="fas fa-chevron-left"></i></button>
             <button class="testimonial-nav next" aria-label="Suivant"><i class="fas fa-chevron-right"></i></button>

--- a/js/main.js
+++ b/js/main.js
@@ -146,14 +146,15 @@ if (phoneInput) {
 const testimonials = document.querySelectorAll('.testimonial');
 if (testimonials.length > 1) {
     let currentTestimonial = 0;
+    const track = document.querySelector('.testimonial-track');
     const prevButton = document.querySelector('.testimonial-nav.prev');
     const nextButton = document.querySelector('.testimonial-nav.next');
     let autoAdvance;
 
     function showTestimonial(index) {
-        testimonials.forEach((testimonial, i) => {
-            testimonial.style.display = i === index ? 'block' : 'none';
-        });
+        if (track) {
+            track.style.transform = `translateX(-${index * 100}%)`;
+        }
     }
 
     function nextTestimonial() {


### PR DESCRIPTION
## Summary
- add flex-based carousel track and update testimonial styles
- wrap testimonials in a new `.testimonial-track` container
- slide testimonials with JS instead of hide/show

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68679e57da108322af616e06031784ba