### PR TITLE
Fix service section spacing on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -387,6 +387,7 @@ footer {
     align-items: center;
     max-width: 1200px;
     margin: 0 auto;
+    padding: 0 1rem;
 }
 
 .service-detail:nth-child(even) .service-content {


### PR DESCRIPTION
## Summary
- add horizontal padding within service sections so images and text no longer touch screen edges on small devices

## Testing
- `php -l services.php`


------
https://chatgpt.com/codex/tasks/task_e_68acc101d7bc8322a2915166d2daca95