### PR TITLE
Fix mobile menu toggle behaviour

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2,17 +2,27 @@
 document.addEventListener('DOMContentLoaded', function() {
     const mobileToggle = document.querySelector('.mobile-menu-toggle');
     const navLinks = document.querySelector('.nav-links');
-    
-    if (mobileToggle) {
+
+    if (mobileToggle && navLinks) {
         mobileToggle.addEventListener('click', function() {
             navLinks.classList.toggle('active');
             this.textContent = navLinks.classList.contains('active') ? '✕' : '☰';
         });
+
+        // Close menu when a navigation link is selected
+        navLinks.querySelectorAll('a').forEach(link => {
+            link.addEventListener('click', () => {
+                if (navLinks.classList.contains('active')) {
+                    navLinks.classList.remove('active');
+                    mobileToggle.textContent = '☰';
+                }
+            });
+        });
     }
-    
+
     // Close mobile menu when clicking outside
     document.addEventListener('click', function(event) {
-        if (!event.target.closest('nav') && navLinks.classList.contains('active')) {
+        if (mobileToggle && navLinks && !event.target.closest('nav') && navLinks.classList.contains('active')) {
             navLinks.classList.remove('active');
             mobileToggle.textContent = '☰';
         }

--- a/partials/header.php
+++ b/partials/header.php
@@ -15,3 +15,15 @@
         <button class="mobile-menu-toggle" aria-label="Menu">☰</button>
     </nav>
 </header>
+
+<!-- Ensure the mobile menu toggle stays above the navigation drawer -->
+<style>
+    .nav-links {
+        z-index: 1000;
+    }
+
+    .mobile-menu-toggle {
+        position: relative;
+        z-index: 1001;
+    }
+</style>


### PR DESCRIPTION
## Summary
- Ensure burger menu toggle stays above navigation and remains accessible
- Automatically close mobile nav when a link is selected or user taps outside

## Testing
- `php -l partials/header.php`
- `node --check js/main.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68b45f8d19cc832283d8a0dbfea8ed94