### PR TITLE
Fix navbar overlap on homepage

### DIFF
--- a/index.php
+++ b/index.php
@@ -52,7 +52,7 @@ $canonical = $base_url . $_SERVER['REQUEST_URI'];
         /* Header */
         header {
             background-color: var(--text-light);
-            position: fixed;
+            position: sticky;
             width: 100%;
             top: 0;
             z-index: 1000;
@@ -153,7 +153,6 @@ $canonical = $base_url . $_SERVER['REQUEST_URI'];
             justify-content: center;
             position: relative;
             overflow: hidden;
-            padding-top: 80px;
         }
         
         .hero::before {


### PR DESCRIPTION
## Summary
- use sticky positioning for header to prevent overlap on mobile
- remove unnecessary padding from hero section so content starts below navbar

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4be60b0088322974ee33fbd2547a1