### PR TITLE
Display blog posts as responsive image cards

### DIFF
--- a/admin/add_post.php
+++ b/admin/add_post.php
@@ -10,11 +10,23 @@ $message = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title']);
     $content = trim($_POST['content']);
+    $imagePath = '';
+
+    if (!empty($_FILES['image']['name'])) {
+        $uploadDir = '../images/blog/';
+        if (!is_dir($uploadDir)) {
+            mkdir($uploadDir, 0777, true);
+        }
+        $filename = time() . '_' . preg_replace('/[^a-zA-Z0-9._-]/', '_', $_FILES['image']['name']);
+        $target = $uploadDir . $filename;
+        if (move_uploaded_file($_FILES['image']['tmp_name'], $target)) {
+            $imagePath = 'images/blog/' . $filename;
+        }
+    }
+
     if ($title && $content) {
-        // created_at is automatically set by the DB to the current timestamp
-        // so we simply omit it from the INSERT statement
-        $stmt = $db->prepare("INSERT INTO posts (title, content) VALUES (?, ?)");
-        $stmt->execute([$title, $content]);
+        $stmt = $db->prepare("INSERT INTO posts (title, content, image) VALUES (?, ?, ?)");
+        $stmt->execute([$title, $content, $imagePath]);
         $message = 'Article ajouté';
     } else {
         $message = 'Titre et contenu requis';
@@ -37,7 +49,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <?php if ($message): ?>
         <p><?= htmlspecialchars($message) ?></p>
     <?php endif; ?>
-    <form method="post">
+    <form method="post" enctype="multipart/form-data">
         <div class="form-group">
             <label for="title">Titre</label>
             <input type="text" id="title" name="title" required>
@@ -45,6 +57,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <div class="form-group">
             <label for="content">Contenu</label>
             <textarea id="content" name="content" rows="10" required></textarea>
+        </div>
+        <div class="form-group">
+            <label for="image">Image</label>
+            <input type="file" id="image" name="image" accept="image/*">
         </div>
         <button type="submit" class="submit-button">Publier</button>
     </form>

--- a/blog.php
+++ b/blog.php
@@ -404,6 +404,53 @@ $canonical = $base_url . $_SERVER['REQUEST_URI'];
             font-weight: 500;
             letter-spacing: 1px;
         }
+
+        /* Blog cards */
+        .blog-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 2rem;
+        }
+
+        .blog-card {
+            background-color: white;
+            border-radius: 15px;
+            overflow: hidden;
+            box-shadow: var(--shadow);
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+
+        .blog-card img {
+            width: 100%;
+            height: 200px;
+            object-fit: cover;
+        }
+
+        .blog-content {
+            padding: 1.5rem;
+            display: flex;
+            flex-direction: column;
+            flex-grow: 1;
+        }
+
+        .blog-title {
+            margin: 0.5rem 0;
+            font-size: 1.3rem;
+            color: var(--primary-color);
+        }
+
+        .blog-excerpt {
+            flex-grow: 1;
+            margin-bottom: 1rem;
+        }
+
+        .blog-link {
+            color: var(--primary-color);
+            text-decoration: none;
+            font-weight: 500;
+        }
         
         .forfait-header {
             background-color: var(--primary-color);
@@ -613,9 +660,12 @@ $canonical = $base_url . $_SERVER['REQUEST_URI'];
 <body>
 <?php include 'partials/header.php'; ?>
 <section class="section">
-    <div class="container">
+    <div class="container blog-grid">
         <?php foreach($posts as $post): ?>
-            <article class="blog-card" style="margin-bottom:2rem;">
+            <article class="blog-card">
+                <?php if(!empty($post['image'])): ?>
+                    <img src="<?php echo htmlspecialchars($post['image']); ?>" alt="<?php echo htmlspecialchars($post['title']); ?>">
+                <?php endif; ?>
                 <div class="blog-content">
                     <span class="blog-date"><?php echo date('d/m/Y', strtotime($post['created_at'])); ?></span>
                     <h3 class="blog-title"><?php echo htmlspecialchars($post['title']); ?></h3>

--- a/db.php
+++ b/db.php
@@ -16,6 +16,14 @@ $db->exec("CREATE TABLE IF NOT EXISTS posts (
     id INT AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(255) NOT NULL,
     content TEXT NOT NULL,
+    image VARCHAR(255) DEFAULT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+// Ensure image column exists for older installations
+try {
+    $db->query("SELECT image FROM posts LIMIT 1");
+} catch (PDOException $e) {
+    $db->exec("ALTER TABLE posts ADD COLUMN image VARCHAR(255) DEFAULT NULL AFTER content");
+}
 ?>

--- a/post.php
+++ b/post.php
@@ -21,7 +21,7 @@ $description = mb_substr(strip_tags($post['content']), 0, 160);
     <link rel="canonical" href="<?php echo htmlspecialchars($canonical, ENT_QUOTES); ?>">
     <meta property="og:title" content="<?php echo htmlspecialchars($post['title']); ?>">
     <meta property="og:description" content="<?php echo htmlspecialchars($description); ?>">
-    <meta property="og:image" content="<?php echo htmlspecialchars($base_url . '/images/logo/ALG6.png', ENT_QUOTES); ?>">
+    <meta property="og:image" content="<?php echo htmlspecialchars($base_url . '/' . ($post['image'] ?? 'images/logo/ALG6.png'), ENT_QUOTES); ?>">
     <meta property="og:url" content="<?php echo htmlspecialchars($canonical, ENT_QUOTES); ?>">
     <meta property="og:type" content="article">
     <meta name="theme-color" content="#8B9A7B">
@@ -213,6 +213,15 @@ $description = mb_substr(strip_tags($post['content']), 0, 160);
         .container {
             max-width: 1200px;
             margin: 0 auto;
+        }
+
+        .post-image {
+            width: 100%;
+            max-height: 400px;
+            object-fit: cover;
+            border-radius: 15px;
+            margin-bottom: 2rem;
+            box-shadow: var(--shadow);
         }
         
         .tarifs-intro {
@@ -621,6 +630,9 @@ $description = mb_substr(strip_tags($post['content']), 0, 160);
     <div class="container">
         <h1><?php echo htmlspecialchars($post['title']); ?></h1>
         <p class="blog-date"><?php echo date('d/m/Y', strtotime($post['created_at'])); ?></p>
+        <?php if(!empty($post['image'])): ?>
+            <img src="<?php echo htmlspecialchars($post['image']); ?>" alt="<?php echo htmlspecialchars($post['title']); ?>" class="post-image">
+        <?php endif; ?>
         <div><?php echo nl2br($post['content']); ?></div>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- add `image` column to posts table with backward compatible migration
- enable image upload when adding posts in admin panel
- show blog posts as responsive cards with images and excerpts
- display post images on individual article pages

## Testing
- `php -l db.php`
- `php -l admin/add_post.php`
- `php -l blog.php`
- `php -l post.php`


------
https://chatgpt.com/codex/tasks/task_e_68be913725908322896c9c3263200374